### PR TITLE
Potential fix for code scanning alert no. 51: Log entries created from user input

### DIFF
--- a/Controllers/JobStatusController.cs
+++ b/Controllers/JobStatusController.cs
@@ -94,7 +94,8 @@ namespace WorkoutTrackerWeb.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error getting job status for job {JobId}", jobId);
+                var sanitizedJobId = jobId.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+                _logger.LogError(ex, "Error getting job status for job {JobId}", sanitizedJobId);
                 return StatusCode(500, new { message = "An error occurred while checking job status", error = ex.Message });
             }
         }


### PR DESCRIPTION
Potential fix for [https://github.com/ninjatec/WorkoutTracker/security/code-scanning/51](https://github.com/ninjatec/WorkoutTracker/security/code-scanning/51)

To fix the issue, we will sanitize the `jobId` parameter before logging it. Since the logs are likely plain text, we will remove any newline characters from the `jobId` using `String.Replace` to prevent log forging. This ensures that the user input cannot introduce new log entries or otherwise manipulate the log format.

The changes will be made in the `catch` block on line 97, where the `jobId` is logged. We will sanitize the `jobId` before passing it to the `_logger.LogError` method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
