### PR TITLE
Potential fix for code scanning alert no. 84: Clear-text logging of sensitive information

### DIFF
--- a/scripts/rotate-sql-credentials.py
+++ b/scripts/rotate-sql-credentials.py
@@ -298,7 +298,7 @@ class SQLCredentialRotator:
                     path=backup_path,
                     secret=current_secret['data']['data']
                 )
-                logger.info(f"Created backup at: {backup_path}")
+                logger.info("Backup created successfully.")
             
             # Update with new credentials
             current_secret = self.vault_client.secrets.kv.v2.read_secret_version(


### PR DESCRIPTION
Potential fix for [https://github.com/ninjatec/WorkoutTracker/security/code-scanning/84](https://github.com/ninjatec/WorkoutTracker/security/code-scanning/84)

To address this issue, sensitive information should be excluded from the logs. Instead of logging the full `backup_path`, we can log generic or anonymized messages that still convey useful information without revealing sensitive details. For example, we can log a generic success message indicating that a backup was created, without including the actual path. This ensures that the logs remain informative while protecting sensitive data.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
