### PR TITLE
Potential fix for code scanning alert no. 83: Clear-text logging of sensitive information

### DIFF
--- a/scripts/check-rotation-health.py
+++ b/scripts/check-rotation-health.py
@@ -42,16 +42,23 @@ class RotationHealthChecker:
         self.sql_server = sql_server
         self.issues = []
         self.warnings = []
+        self.redacted_values = {
+            self.secret_path: "[REDACTED]",
+            self.vault_token: "[REDACTED]",
+            self.sql_server: "[REDACTED]",
+        }
         
     def add_issue(self, issue: str):
         """Add a critical issue"""
-        self.issues.append(issue)
-        logger.error(f"ISSUE: {issue}")
+        sanitized_issue = self._sanitize_message(issue)
+        self.issues.append(sanitized_issue)
+        logger.error(f"ISSUE: {sanitized_issue}")
         
     def add_warning(self, warning: str):
         """Add a warning"""
-        self.warnings.append(warning)
-        logger.warning(f"WARNING: {warning}")
+        sanitized_warning = self._sanitize_message(warning)
+        self.warnings.append(sanitized_warning)
+        logger.warning(f"WARNING: {sanitized_warning}")
         
     def check_vault_connectivity(self) -> bool:
         """Check if Vault is accessible and token is valid"""


### PR DESCRIPTION
Potential fix for [https://github.com/ninjatec/WorkoutTracker/security/code-scanning/83](https://github.com/ninjatec/WorkoutTracker/security/code-scanning/83)

To fix the issue, we need to prevent sensitive information from being logged in clear text. The best approach is to redact sensitive data like the `secret_path` or replace it with a placeholder in log messages. We can introduce a utility function that sanitizes error messages before they are written to logs. This function will replace sensitive values with a generic placeholder (e.g., `[REDACTED]`). We will apply this sanitization in the `add_issue` and `add_warning` methods during logging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
